### PR TITLE
add the ability to hide the cursor when a VN script starts

### DIFF
--- a/data/tables/vs3-sct.tbm
+++ b/data/tables/vs3-sct.tbm
@@ -6,19 +6,21 @@ $On Game Init:
 
 VS3 = {}
 
-function VS3:Init(ingame)
+function VS3:Init(hideCursor)
 	--THIS IS VERSION 3.0.3
-
-
+	
+	
 	ba.print("*****Initializing Visual Novel System...\n")
 	
-	io.setCursorHidden(false)
+	-- if nil (not specified), assume false
+	hideCursor = hideCursor or false
+	io.setCursorHidden(hideCursor)
 	
 	self.Lexer = require ("lexer.lua")
 	--self.Ease = require ("easing.lua")
 	
 	self.SDL2 = true
-
+	
 	self.CanTalk = nil
 	self.Running = true
 	self.Enabled = false
@@ -72,7 +74,7 @@ function VS3:Init(ingame)
 	
 	self.Fade = nil	
 	
-	self.ShowCursor = true
+	self.ShowCursor = (not hideCursor)
 	self.ShowBox = false
 	self.HideFlag = false
 	
@@ -106,25 +108,38 @@ function VS3:Init(ingame)
 
 end
 
-;;FSO 3.8.1.20180119;;  mn.LuaSEXPs["lua-vn-load"].Action = function(filename, start)
+mn.LuaSEXPs["lua-vn-load"].Action = function(filename, start, hideCursor)
 
-;;FSO 3.8.1.20180119;;		local ext = ".txt"
+	local ext = ".txt"
 	
-;;FSO 3.8.1.20180119;;		if not filename:ends(ext) then
-;;FSO 3.8.1.20180119;;			filename = filename .. ext
-;;FSO 3.8.1.20180119;;		end
-		
-;;FSO 3.8.1.20180119;;		VS3:LoadScene(filename, start)
+	if not filename:ends(ext) then
+		filename = filename .. ext
+	end
 
-;;FSO 3.8.1.20180119;;  end
+	-- simulate not supplying the "start" argument if we're forced to supply it
+	if start then
+		if start == "" or start:lower() == "none" then
+			start = nil
+		end
+	end
+	
+	VS3:LoadScene{filename=filename, start=start, hideCursor=hideCursor}
 
-function VS3:L(filename,start,stayInGame)
+end
 
-	self:LoadScene(filename .. ".txt", start,stayInGame)
+function VS3:L(filename, start, stayInGame)
+
+	self:LoadScene{filename=filename .. ".txt", start=start, stayInGame=stayInGame}
 	
 end
 
-function VS3:LoadScene(filename, start, stayInGame)
+function VS3:LoadScene(args)
+
+	-- use table syntax in case one or more of the args isn't specified
+	local filename = args.filename
+	local start = args.start
+	local stayInGame = args.stayInGame
+	local hideCursor = args.hideCursor
 
 	if not cf.fileExists(filename, "data/fiction", true) then
 		ba.error("VN Script: File " .. filename .. " was not found!\n")
@@ -135,7 +150,7 @@ function VS3:LoadScene(filename, start, stayInGame)
 			start = string.lower(start)
 		end
 	
-		VS3:Init()
+		VS3:Init(hideCursor)
 		
 		if Lockdown and self.Config.LockByDefault then Lockdown() end
 		
@@ -235,7 +250,7 @@ function VS3:BatchErrorCheck(...)
 	self.DebugBatchMode = true
 
 	for i,v in ipairs(arg) do
-		self:LoadScene(v, nil, true)
+		self:LoadScene{filename=v, start=nil, stayInGame=true}
 	end
 
 end

--- a/data/tables/vs3-sexp.tbm
+++ b/data/tables/vs3-sexp.tbm
@@ -4,14 +4,17 @@ $Operator: lua-vn-load
 $Category: Change
 $Subcategory: Scripted
 $Minimum Arguments: 1
-$Maximum Arguments: 2
+$Maximum Arguments: 3
 $Return Type: Nothing
 $Description: It began with the forging of the great SEXPs. Three were given to the coders, wisest and fairest of all beings. Seven to the model-lords, great mappers and texturers of the nebula halls. And nine, and nine sexps were gifted to the race of FREDders, who above all else desire power. For within these SEXPs was bound the strength and will to make new missions and campaigns. But they were all of them deceived... For another SEXP was made. In the land of Anime Mods, in the fires of Mount Lazy, the Dark Scripter Axem forged in secret a master SEXP, to control all words. And into this SEXP, he poured his text, his sprites, and his will to dominate the player's attention. ONE SEXP TO RULE THEM ALL. ONE SEXP TO READ THEM. ONE SEXP TO BRING THEM ALL, AND IN THE WORDS, BIND THEM.
 $Parameter:
 	+Description: VN file to load stored in the /fiction/ folder. Does not need the .txt extension (but can if you want)
 	+Type: string
 $Parameter:
-	+Description: VN label to begin at (optional, if left out, the VN file will start at the top)
+	+Description: VN label to begin at (optional$semicolon if left out, or blank, or 'none', the VN file will start at the top)
 	+Type: string
+$Parameter:
+	+Description: Whether to hide the cursor when the VN starts (optional$semicolon defaults to false)
+	+Type: boolean
 
 #End


### PR DESCRIPTION
Adds an extra parameter to the sexp and slightly reorganizes the API to accommodate it.

Also removes the version-specific commenting from the SEXP definition, because modders are likely not going to run the version 3 script on a build that old.